### PR TITLE
docs: Use upstream theme & update to 0.4.1

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -11,7 +11,7 @@ kramdown:
     ndash: "--"
     mdash: "---"
 
-remote_theme: coreos/just-the-docs
+remote_theme: just-the-docs/just-the-docs@v0.4.1
 plugins:
   - jekyll-remote-theme
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,7 @@
 title: coreos/coreos-assembler
 description: coreos-assembler documentation
 baseurl: "/coreos-assembler"
-url: "https://coreos.github.io"
+url: "https://travier.github.io"
 # Comment above and use below for local development
 # url: "http://localhost:4000"
 permalink: /:title/


### PR DESCRIPTION
Use a fixed tag for the theme so that we can directly pull it from
upstream and skip vendoring the theme in the coreos org.



------- 
@travier i moved a couple of commits you had on `main` to this branch and updated main to match coreos/coreos-assembler